### PR TITLE
use image naturalWidth and naturalHeight for consistent result

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -31,8 +31,8 @@ import core from './core.js';
 const CanvasImage = function (image) {
     this.canvas  = document.createElement('canvas');
     this.context = this.canvas.getContext('2d');
-    this.width  = this.canvas.width  = image.width;
-    this.height = this.canvas.height = image.height;
+    this.width  = this.canvas.width  = image.naturalWidth;
+    this.height = this.canvas.height = image.naturalHeight;
     this.context.drawImage(image, 0, 0, this.width, this.height);
 };
 


### PR DESCRIPTION
Currently we are using the `width` and `height` attributes of the `HTMLImageElement` to set the size of the created `HTMLCanvasElement`. However these two attributes are depending on the styles of the `HTMLImageElement` which means two `img`s with the same `src` will output different color. This will make the result inconsistent and untestable.

Use the `naturalWidth` and `naturalHeight` will set the size of the canvas the same as the intrinsic size of the image file. This will assure the pixelcount is always the same for the same image file.

